### PR TITLE
Change default ETModel port

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,7 +8,7 @@ output_file_folder: data/output
 
 # Where your local model is run
 local_engine_url: http://localhost:3000/api/v3
-local_model_url: http://localhost:4000
+local_model_url: http://localhost:3001
 
 # The separator your CSV files are using. The default is ',', but many European computers
 # export CSV with a ';' as separator from Excel instead.


### PR DESCRIPTION
This updates the ETModel port in the settings file to use 3001. This is the default in the ETModel docker-compose.yml.

I'm open to alternatives, including changing the default port used by ETModel's docker-compose.yml, but either way want to match up the settings to make it easier for third-parties who are running their own copy of the model.