### PR TITLE
Change protected to keep_compatible, add to scenario_list import

### DIFF
--- a/data/input/scenario_list.csv
+++ b/data/input/scenario_list.csv
@@ -1,2 +1,2 @@
-short_name,title,area_code,end_year,description,id,heat_network_order,curve_file,heat_demand
-test_scen,Scenario-Tools Test Scenario,GM0363_amsterdam,2050,"""test scenario""",892503,energy_heat_burner_waste_mix energy_heat_burner_network_gas,2050_price_curves,
+short_name,title,area_code,end_year,description,id,keep_compatible,heat_network_order,curve_file,heat_demand
+test_scen,Scenario-Tools Test Scenario,GM0363_amsterdam,2050,"""test scenario""",892503,False,energy_heat_burner_waste_mix energy_heat_burner_network_gas,2050_price_curves,

--- a/helpers/ETM_API.py
+++ b/helpers/ETM_API.py
@@ -149,7 +149,7 @@ class ETM_API(object):
         """
         Update scenario properties such as title and description
         """
-        print(" Setting scenario title, description and protected status")
+        print(" Setting scenario title, description and keep_compatible status")
 
         put_data = {
             "scenario": self.scenario.properties_as_json()

--- a/helpers/Scenario.py
+++ b/helpers/Scenario.py
@@ -21,7 +21,7 @@ class Scenario:
         "area_code",
         "end_year",
         "description",
-        "protected",
+        "keep_compatible",
         "curve_file",
         "custom_curves",
         "flexibility_order",
@@ -35,7 +35,7 @@ class Scenario:
             try:
                 if pd.notna(scenario_list[key]):
                     setattr(self, key, scenario_list[key])
-                elif key == 'protected':
+                elif key == 'keep_compatible':
                     setattr(self, key, False)
                 else:
                     setattr(self, key, None)
@@ -79,7 +79,7 @@ class Scenario:
                 'title': self.title if self.title else '',
                 'description': self.description if self.description else '',
             },
-            'protected': self.protected
+            'keep_compatible': self.keep_compatible
         }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ def default_scenario(test_data=None):
     '''
     index = [
         'short_name','title','area_code','end_year',
-        'description','id','protected','flexibility_order',
+        'description','id','keep_compatible','flexibility_order',
         'heat_network_order','curve_file','heat_demand'
     ]
     test_data = test_data if test_data else [

--- a/tests/fixtures/scenario_list.csv
+++ b/tests/fixtures/scenario_list.csv
@@ -1,2 +1,2 @@
-short_name,title,area_code,end_year,description,id,protected,heat_network_order,curve_file,heat_demand
+short_name,title,area_code,end_year,description,id,keep_compatible,heat_network_order,curve_file,heat_demand
 test_scen,Scenario-Tools Test Scenario,GM0363_amsterdam,2050,"""test scenario""",,,energy_heat_burner_waste_mix energy_heat_burner_network_gas,,


### PR DESCRIPTION
## What?
This PR changes the `protected` attribute, which is the deprecated predecessor of `keep_compatible`, to `keep_compatible`. It also adds this column to the `scenario_list` CSV import example (functionality-wise importing the `protected` attribute was already supported).

## Why?
To keep the scenario tools up to date with the current `Scenario` model in ETEngine.

## How?
Minor changes in several scripts, see code changes for details.

Closes #30