### PR TITLE
Fixed default CSV inputs for scenario_from_csv

### DIFF
--- a/data/input/heat_network_orders.csv
+++ b/data/input/heat_network_orders.csv
@@ -1,4 +1,4 @@
 order,test_scen
 heat_network_order_lt,
-heat_network_order_mt,energy_heat_burner_waste_mix energy_heat_burner_network_gas
+heat_network_order_mt,energy_heat_burner_mt_waste_mix energy_heat_burner_mt_network_gas
 heat_network_order_ht,

--- a/data/input/queries.csv
+++ b/data/input/queries.csv
@@ -1,3 +1,3 @@
 query
-dashboard_total_costs_per_household
+dashboard_co2_emissions_versus_start_year
 dashboard_total_costs


### PR DESCRIPTION
The default settings in the input CSVs raised errors when running scenario_from_csv since these settings were outdated. This PR solves this by using up-to-date settings. 

Closes https://github.com/quintel/scenario-tools/issues/36