### PR TITLE
Include internal curves in custom curve CSV export

### DIFF
--- a/helpers/ETM_API.py
+++ b/helpers/ETM_API.py
@@ -134,8 +134,9 @@ class ETM_API(object):
         '''
         Get custom curves attached to the scenario.
         Collects custom curves in one pd.DataFrame output.
+        Internal curves (not visible in the frontend if uploaded) are included.
         '''
-        response = self.session.get(f"/scenarios/{self.scenario.id}/custom_curves")
+        response = self.session.get(f"/scenarios/{self.scenario.id}/custom_curves?include_internal=true")
         self.handle_response(
             response,
             fail_info="Error obtaining custom curves.\n")


### PR DESCRIPTION
The internal curves are now included in API request `get_custom_curves()`. These curves are hidden in the frontend if uploaded, example: `insulation_terraced_houses_high`. 

The curve export obtained from the `get_template_settings` module can be directly uploaded to an existing or new scenario through the `scenario_from_csv` module. 

Relates to https://github.com/quintel/etengine/issues/1431#issuecomment-2498027511